### PR TITLE
talks: add URL fragment identifier

### DIFF
--- a/templates/en/talks.html.jinja2
+++ b/templates/en/talks.html.jinja2
@@ -12,7 +12,7 @@
 
   {% for talk in talks %}
     <article>
-      <h3>{{ talk.title }}</h3>
+      <h3 id="{{ talk.title.replace(' ', '-') }}">{{ talk.title }}</h3>
       <p>
         By {{ talk.person }}
         {% if category == 'sprint' %}

--- a/templates/fr/talks.html.jinja2
+++ b/templates/fr/talks.html.jinja2
@@ -12,7 +12,7 @@
 
   {% for talk in talks %}
     <article>
-      <h3>{{ talk.title }}</h3>
+      <h3 id="{{ talk.title.replace(' ', '-') }}">{{ talk.title }}</h3>
       <p>
         Par {{ talk.person }}
         {% if category == 'sprint' %}


### PR DESCRIPTION
talks: add [URL fragment identifier](https://en.wikipedia.org/wiki/Fragment_identifier).

According to this [doc](https://www.w3schools.com/tags/att_global_id.asp), rules for ` id` are:
* must contain at least one character
* must not contain any space characters

I assume that `title` is always string.