### PR TITLE
talks pages: define 'page_name'

### DIFF
--- a/templates/en/talks.html.jinja2
+++ b/templates/en/talks.html.jinja2
@@ -2,6 +2,7 @@
 
 {% set days = {'2019-11-02': 'Saturday', '2019-11-03': 'Sunday'} %}
 {% set titles = {'conference': 'Talks', 'workshop': 'Workshops', 'sprint': 'Sprints', 'keynote': 'Keynotes'} %}
+{% set page_name = category %}
 
 {% block content %}
   <hgroup>

--- a/templates/fr/talks.html.jinja2
+++ b/templates/fr/talks.html.jinja2
@@ -2,6 +2,7 @@
 
 {% set days = {'2019-11-02': 'Samedi', '2019-11-03': 'Dimanche'} %}
 {% set titles = {'conference': 'Conférences', 'workshop': 'Ateliers', 'sprint': 'Sprints', 'keynote': 'Plénières'} %}
+{% set page_name = category %}
 
 {% block content %}
   <hgroup>


### PR DESCRIPTION
talks pages: define 'page_name' in order to avoid empty 'id' attribute for 'body' tags